### PR TITLE
Add plone.contentratings until ZODB cruft can be removed

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -49,6 +49,7 @@ eggs =
     plone4.csrffixes
 # needed for cruft in ZODB
     contentratings
+    plone.contentratings
     plone.app.ldap
     Products.PloneHotfix20210518
 


### PR DESCRIPTION
Will remove pleiades.portlet.pelagios from egg list after product uninstalled on production and staging